### PR TITLE
v7.1.3 — Config persistence diagnostics (#17)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stash-jellyfin-proxy"
-version = "7.1.2"
+version = "7.1.3"
 description = "Proxy that lets Jellyfin clients (Infuse, Findroid, etc.) browse and stream a Stash library."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/stash_jellyfin_proxy/__init__.py
+++ b/stash_jellyfin_proxy/__init__.py
@@ -17,3 +17,8 @@ Subpackage layout (see CLAUDE.md §Architecture for details):
 runtime.py holds all shared config + mutable state (single source of
 truth; see its docstring).
 """
+
+# Single source of truth for the package version. Keep in sync with
+# pyproject.toml `[project].version`. The startup banner, dashboard
+# API, and HTML brand badge all read this constant.
+__version__ = "7.1.3"

--- a/stash_jellyfin_proxy/__main__.py
+++ b/stash_jellyfin_proxy/__main__.py
@@ -73,6 +73,7 @@ def main():
     )
 
     # Proxy imports deferred until env vars are in place.
+    import stash_jellyfin_proxy as _pkg
     import stash_jellyfin_proxy.runtime as _runtime
     from stash_jellyfin_proxy.config.bootstrap import run_bootstrap
     run_bootstrap(CONFIG_FILE, LOCAL_CONFIG_FILE)
@@ -126,7 +127,7 @@ def main():
     logging.getLogger("hypercorn.error").addFilter(SuppressDisconnectFilter())
     logging.getLogger("asyncio").setLevel(logging.CRITICAL)
 
-    logger.info("--- Stash-Jellyfin Proxy v7.1.1 ---")
+    logger.info(f"--- Stash-Jellyfin Proxy v{_pkg.__version__} ---")
 
     if not check_stash_connection():
         logger.warning("Could not connect to Stash. Proxy will start but streaming will not work until Stash is reachable.")

--- a/stash_jellyfin_proxy/config/bootstrap.py
+++ b/stash_jellyfin_proxy/config/bootstrap.py
@@ -412,30 +412,67 @@ def run_bootstrap(config_file: str, local_config_file: str) -> None:
     _uuid_padded = SERVER_ID.replace("-", "").ljust(32, "0")[:32]
     USER_ID = str(uuid.uuid5(uuid.UUID(_uuid_padded), SJS_USER or "user"))
 
-    # ---- Probe config-file writability ----
-    # If the file (or its parent dir, when the file doesn't yet exist)
-    # isn't writable, SERVER_ID and ACCESS_TOKEN can't persist — they'll
-    # regenerate on every restart and break client reconnects.
-    # We do both an os.access check (catches non-root users) and an
-    # open('r+') probe (catches read-only filesystem mounts, where root
-    # would otherwise bypass DAC and look writable).
+    # ---- Probe config-file writability + cross-boot persistence ----
+    # We write a per-boot timestamp (CONFIG_LAST_BOOT_AT) and a one-time
+    # introduction marker (CONFIG_PERSISTENCE_INTRODUCED). The pair lets
+    # us classify the file state into four buckets:
+    #   persisted      — INTRODUCED present + LAST_BOOT_AT survived prior boot
+    #   not_persistent — INTRODUCED present but LAST_BOOT_AT missing (wiped)
+    #   not_writable   — couldn't write the marker now (perms / read-only)
+    #   unverified     — fresh install, or first boot after upgrade-to-this-
+    #                    version; need another boot to know
+    # Captures from cfg below reflect file contents at load time, before
+    # any of bootstrap's own writes (SERVER_ID/ACCESS_TOKEN/LAST_BOOT_AT).
+    import datetime
+    prior_last_boot_at = (cfg.get("CONFIG_LAST_BOOT_AT", "") or "").strip()
+    prior_introduced = (cfg.get("CONFIG_PERSISTENCE_INTRODUCED", "") or "").strip()
+    had_server_id_at_load = bool((cfg.get("SERVER_ID", "") or "").strip())
+
+    now_iso = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    CONFIG_LAST_BOOT_AT = now_iso
+
     CONFIG_WRITABLE = True
-    if os.path.isfile(config_file):
-        if not os.access(config_file, os.W_OK):
+    CONFIG_PERSISTENCE = "unverified"
+    write_error = None
+    try:
+        save_config_value(
+            config_file, "CONFIG_LAST_BOOT_AT", now_iso,
+            "Updated every successful boot. If missing on a later boot the config wasn't persisted.",
+        )
+        # Verify the write actually landed by re-reading. Catches the
+        # rare case of a write that returns success but doesn't commit
+        # (e.g., overlay/tmpfs misconfigurations).
+        verify_cfg, _, _ = load_config(config_file)
+        if (verify_cfg.get("CONFIG_LAST_BOOT_AT", "") or "").strip() != now_iso:
             CONFIG_WRITABLE = False
-        else:
-            try:
-                with open(config_file, "r+"):
-                    pass
-            except OSError:
-                CONFIG_WRITABLE = False
-    else:
-        parent = os.path.dirname(os.path.abspath(config_file)) or "."
-        if not os.access(parent, os.W_OK):
-            CONFIG_WRITABLE = False
+            write_error = "write succeeded but read-back returned a different value"
+        elif not prior_introduced:
+            # First boot that's writing markers. Plant the introduction
+            # stamp so future boots can distinguish "fresh install" from
+            # "file got wiped after we'd been running here."
+            save_config_value(
+                config_file, "CONFIG_PERSISTENCE_INTRODUCED", now_iso,
+                "Set once, on the first boot that wrote CONFIG_LAST_BOOT_AT. Used to detect file resets.",
+            )
+    except OSError as e:
+        CONFIG_WRITABLE = False
+        write_error = str(e)
+
     if not CONFIG_WRITABLE:
+        CONFIG_PERSISTENCE = "not_writable"
         print(f"  WARNING: Config file is not writable: {config_file}")
+        if write_error:
+            print(f"  Write error: {write_error}")
         print("  SERVER_ID and ACCESS_TOKEN cannot persist; clients will need to re-add the server after every restart.")
+    elif had_server_id_at_load and prior_introduced:
+        if prior_last_boot_at:
+            CONFIG_PERSISTENCE = "persisted"
+        else:
+            CONFIG_PERSISTENCE = "not_persistent"
+            print(f"  WARNING: Config file is writable but did not survive the prior restart.")
+            print(f"  CONFIG_PERSISTENCE_INTRODUCED was set on {prior_introduced}, but CONFIG_LAST_BOOT_AT is missing.")
+            print(f"  Likely cause: /config mounted as an anonymous Docker volume or tmpfs, or not mounted at all.")
+            print(f"  Settings, SERVER_ID, and ACCESS_TOKEN will reset on every restart until /config is fixed.")
 
     # ---- Publish to stash_jellyfin_proxy.runtime ----
     runtime.publish(
@@ -480,6 +517,8 @@ def run_bootstrap(config_file: str, local_config_file: str) -> None:
         CONFIG_FILE=config_file,
         LOCAL_CONFIG_FILE=local_config_file,
         CONFIG_WRITABLE=CONFIG_WRITABLE,
+        CONFIG_PERSISTENCE=CONFIG_PERSISTENCE,
+        CONFIG_LAST_BOOT_AT=CONFIG_LAST_BOOT_AT,
         config=cfg,
         config_defined_keys=cfg_defined_keys,
         config_sections=cfg_sections,

--- a/stash_jellyfin_proxy/runtime.py
+++ b/stash_jellyfin_proxy/runtime.py
@@ -86,6 +86,20 @@ LOCAL_CONFIG_FILE: str = ""
 # rotate on every restart, breaking client reconnects (issue #16).
 CONFIG_WRITABLE: bool = True
 
+# Result of the boot-time persistence probe (issue #17). One of:
+#   "persisted"      — file survived the prior boot (LAST_BOOT_AT marker found)
+#   "not_persistent" — INTRODUCED marker present but LAST_BOOT_AT missing,
+#                      meaning the file got wiped between boots (anonymous
+#                      Docker volume, tmpfs, missing /config mount)
+#   "not_writable"   — couldn't write the marker this boot
+#   "unverified"     — first run, or first boot after upgrading to a build
+#                      that writes these markers; can't classify yet
+CONFIG_PERSISTENCE: str = "unverified"
+# ISO-8601 UTC timestamp written to the config every successful boot.
+# Surfaced read-only on the dashboard so operators can see the last
+# boot time even when the file was just wiped.
+CONFIG_LAST_BOOT_AT: str = ""
+
 # --- Fixed identity strings ---
 # The Jellyfin protocol version we pretend to be. Bump when clients
 # require newer API features.

--- a/stash_jellyfin_proxy/ui/api.py
+++ b/stash_jellyfin_proxy/ui/api.py
@@ -16,7 +16,7 @@ from typing import Optional
 
 from starlette.responses import JSONResponse, Response
 
-from stash_jellyfin_proxy import runtime
+from stash_jellyfin_proxy import __version__, runtime
 from stash_jellyfin_proxy.stash.client import check_stash_connection_cached, stash_query
 from stash_jellyfin_proxy.state import stats as _stats
 from stash_jellyfin_proxy.state import streams as _streams
@@ -43,7 +43,7 @@ async def ui_api_status(request):
     uptime_seconds = int(time.time() - start_time) if start_time else 0
     return JSONResponse({
         "running": runtime.PROXY_RUNNING,
-        "version": "v7.0.0",
+        "version": f"v{__version__}",
         "proxyBind": runtime.PROXY_BIND,
         "proxyPort": runtime.PROXY_PORT,
         "uptime": uptime_seconds,

--- a/stash_jellyfin_proxy/ui/api.py
+++ b/stash_jellyfin_proxy/ui/api.py
@@ -53,6 +53,8 @@ async def ui_api_status(request):
         "migrationPerformed": bool(getattr(runtime, "MIGRATION_PERFORMED", False)),
         "migrationLog": list(getattr(runtime, "MIGRATION_LOG", []) or []),
         "configWritable": bool(getattr(runtime, "CONFIG_WRITABLE", True)),
+        "configPersistence": getattr(runtime, "CONFIG_PERSISTENCE", "unverified"),
+        "configLastBootAt": getattr(runtime, "CONFIG_LAST_BOOT_AT", ""),
         "configFile": runtime.CONFIG_FILE,
     })
 

--- a/stash_jellyfin_proxy/ui/static/app.js
+++ b/stash_jellyfin_proxy/ui/static/app.js
@@ -315,6 +315,18 @@ async function renderDashStatus() {
     } else {
       cwBanner.classList.add("hide");
     }
+
+    // Config-not-persistent banner — file is writable but didn't survive
+    // the prior restart (anonymous volume, tmpfs, missing /config mount).
+    // Suppressed when not_writable already shows, since that one is the
+    // upstream problem and persistence can't be tested without writes.
+    const cpBanner = qs("#dash-config-persistence-banner");
+    if (s.configPersistence === "not_persistent" && s.configWritable !== false) {
+      qs("#dash-config-persistence-path").textContent = s.configFile || "(unknown)";
+      cpBanner.classList.remove("hide");
+    } else {
+      cpBanner.classList.add("hide");
+    }
   } catch {}
 }
 

--- a/stash_jellyfin_proxy/ui/templates/index.html
+++ b/stash_jellyfin_proxy/ui/templates/index.html
@@ -13,7 +13,7 @@
   <aside class="sidebar">
     <div class="brand">
       <div class="logo"><span class="hex">⬡</span> SJP</div>
-      <div class="ver" id="brand-version">v7.0.0</div>
+      <div class="ver" id="brand-version"></div>
     </div>
     <nav class="nav" id="nav">
       <div class="nav-item active" data-page="dashboard"><span class="dot"></span>Dashboard</div>

--- a/stash_jellyfin_proxy/ui/templates/index.html
+++ b/stash_jellyfin_proxy/ui/templates/index.html
@@ -143,6 +143,17 @@
           </div>
         </div>
 
+        <!-- Row 4b: Config-not-persistent warning (conditional) -->
+        <div class="card hide" id="dash-config-persistence-banner" style="margin-top: 16px; border-color: #dc2626; background: rgba(220, 38, 38, 0.08);">
+          <div class="card-body">
+            <div>
+              <strong style="color: #dc2626;">⚠ Config file is not surviving restarts.</strong>
+              <code id="dash-config-persistence-path"></code> is writable, but the marker we wrote on the previous boot is gone — the file got wiped between restarts. Settings, <strong>SERVER_ID</strong>, and <strong>ACCESS_TOKEN</strong> will keep resetting until this is fixed.
+              <div style="margin-top: 6px; color: var(--text-dim); font-size: 13px;">Most likely cause: <code>/config</code> is mounted as an anonymous Docker volume, or the volume isn't actually mounted (so writes land in the container's ephemeral layer and vanish on restart). Check your <code>docker run -v</code> / <code>docker-compose</code> volume mapping.</div>
+            </div>
+          </div>
+        </div>
+
         <!-- Row 4: Migration notice (conditional) -->
         <div class="card hide" id="dash-migration-banner" style="margin-top: 16px; border-color: var(--accent, #3b82f6);">
           <div class="card-body" style="display: flex; justify-content: space-between; align-items: center; gap: 16px;">


### PR DESCRIPTION
## Summary
- **Centralize version reporting** on a single `__version__` constant. Three hardcoded version strings had drifted across releases (`__main__.py` startup banner stuck at v7.1.1, dashboard `/api/status` stuck at v7.0.0, HTML brand badge stuck at v7.0.0), so users couldn't verify which build they were actually running.
- **Detect non-persistent config files** (issue #17). Bootstrap now writes `CONFIG_LAST_BOOT_AT` every boot and a one-time `CONFIG_PERSISTENCE_INTRODUCED` marker. Combined with prior `SERVER_ID` presence, classify the config into one of `persisted` / `not_persistent` / `not_writable` / `unverified` and surface in the dashboard. Replaces the previous `os.access + open(r+)` probe with a stricter write-and-read-back round trip.

## Why this matters for #17
juliuswong's `FAVORITE_TAG` blanks out after every restart, which short-circuits all favorite-related code paths (the v7.1.2 case-insensitive comparison fix is irrelevant if the tag value itself is empty). The most likely root cause is that his `/config` volume isn't actually persisting between container restarts — anonymous Docker volume, tmpfs, or a missing mount. Without server-side detection, this looks identical to a save bug. The new `not_persistent` banner names the likely cause directly.

## Test plan
- [x] Unit tests pass (104/104)
- [x] Browser smoke harness clean across 12 routes
- [x] State transitions verified in dev container:
  - upgrade-from-pre-marker → `unverified`, both markers planted
  - normal restart → `persisted`
  - manually strip `CONFIG_LAST_BOOT_AT` → `not_persistent` (banner shows)
- [ ] juliuswong pulls v7.1.3 and reports the dashboard state — expecting `not_persistent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)