### PR TITLE
v7.1.4 — Fix persistence-marker placement and comment dup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stash-jellyfin-proxy"
-version = "7.1.3"
+version = "7.1.4"
 description = "Proxy that lets Jellyfin clients (Infuse, Findroid, etc.) browse and stream a Stash library."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/stash_jellyfin_proxy/__init__.py
+++ b/stash_jellyfin_proxy/__init__.py
@@ -21,4 +21,4 @@ truth; see its docstring).
 # Single source of truth for the package version. Keep in sync with
 # pyproject.toml `[project].version`. The startup banner, dashboard
 # API, and HTML brand badge all read this constant.
-__version__ = "7.1.3"
+__version__ = "7.1.4"

--- a/stash_jellyfin_proxy/config/helpers.py
+++ b/stash_jellyfin_proxy/config/helpers.py
@@ -82,11 +82,18 @@ def save_config_value(config_file: str, key: str, value: str, comment: str = Non
         lines = f.readlines()
 
     # Strip every existing line for this key (active or commented),
-    # regardless of section. Track where the first section header sits.
+    # regardless of section. Also strip any prior occurrence of the
+    # same comment line we're about to insert — otherwise repeated
+    # saves of a per-boot key (CONFIG_LAST_BOOT_AT) accumulate one
+    # extra comment copy per boot. Track where the first section
+    # header sits.
+    comment_marker = f'# {comment}'.strip() if comment else None
     cleaned = []
     first_section_idx = None
     for line in lines:
         if _line_matches_key(line, key):
+            continue
+        if comment_marker and line.strip() == comment_marker:
             continue
         stripped = line.strip()
         if first_section_idx is None and stripped.startswith('[') and stripped.endswith(']'):
@@ -105,8 +112,20 @@ def save_config_value(config_file: str, key: str, value: str, comment: str = Non
             cleaned.append('\n')
         cleaned.extend(new_block)
     else:
+        # Walk back past blank lines and any decorative "# ==== ... ===="
+        # divider that visually heads the upcoming section, so a flat
+        # global key doesn't land below the divider and look like it
+        # belongs to that section.
+        insertion_idx = first_section_idx
+        j = insertion_idx - 1
+        while j >= 0 and cleaned[j].strip() == '':
+            j -= 1
+        if j >= 0:
+            s = cleaned[j].strip()
+            if s.startswith('# ====') and s.endswith('===='):
+                insertion_idx = j
         new_block.append('\n')
-        cleaned[first_section_idx:first_section_idx] = new_block
+        cleaned[insertion_idx:insertion_idx] = new_block
 
     with open(config_file, 'w') as f:
         f.writelines(cleaned)


### PR DESCRIPTION
## Summary
- **Comment deduplication**: `save_config_value` was matching only `KEY = ...` and `# KEY = ...` lines, so re-saving a key that carried a comment left the prior comment in place and added another — one extra copy per boot for `CONFIG_LAST_BOOT_AT`. Strip loop now also drops any prior occurrence of the exact comment line being re-inserted.
- **Placement**: Persistence markers were landing between the `# ==== Player profiles ====` divider and the first `[player.*]` header, visually appearing to belong to the profiles section. Insertion now walks back past blank lines and any `# ==== ... ====` divider, placing flat global keys *above* the divider where they belong.

Both fixes are in `save_config_value` itself, so SERVER_ID and ACCESS_TOKEN inherit the same correct behavior if their comments ever change.

## Test plan
- [x] Unit tests pass (104/104)
- [x] Three consecutive restarts in dev: exactly one comment line + one value line, sitting above the divider, `persisted` state stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)