### PR TITLE
v7.1.5 — Heal misplaced persistence markers from v7.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stash-jellyfin-proxy"
-version = "7.1.4"
+version = "7.1.5"
 description = "Proxy that lets Jellyfin clients (Infuse, Findroid, etc.) browse and stream a Stash library."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/stash_jellyfin_proxy/__init__.py
+++ b/stash_jellyfin_proxy/__init__.py
@@ -21,4 +21,4 @@ truth; see its docstring).
 # Single source of truth for the package version. Keep in sync with
 # pyproject.toml `[project].version`. The startup banner, dashboard
 # API, and HTML brand badge all read this constant.
-__version__ = "7.1.4"
+__version__ = "7.1.5"

--- a/stash_jellyfin_proxy/config/bootstrap.py
+++ b/stash_jellyfin_proxy/config/bootstrap.py
@@ -446,12 +446,18 @@ def run_bootstrap(config_file: str, local_config_file: str) -> None:
         if (verify_cfg.get("CONFIG_LAST_BOOT_AT", "") or "").strip() != now_iso:
             CONFIG_WRITABLE = False
             write_error = "write succeeded but read-back returned a different value"
-        elif not prior_introduced:
-            # First boot that's writing markers. Plant the introduction
-            # stamp so future boots can distinguish "fresh install" from
-            # "file got wiped after we'd been running here."
+        else:
+            # Re-write CONFIG_PERSISTENCE_INTRODUCED every boot. If it
+            # was absent at load time, plant a fresh stamp; if present,
+            # rewrite with its existing value so save_config_value's
+            # placement logic can relocate it (v7.1.3 wrote these
+            # markers between the player-profiles divider and the
+            # first [player.*] header — v7.1.4 fixed the placement
+            # logic, but a one-shot write that already happened in
+            # v7.1.3 stays stuck unless we rewrite it here).
+            introduced_value = prior_introduced or now_iso
             save_config_value(
-                config_file, "CONFIG_PERSISTENCE_INTRODUCED", now_iso,
+                config_file, "CONFIG_PERSISTENCE_INTRODUCED", introduced_value,
                 "Set once, on the first boot that wrote CONFIG_LAST_BOOT_AT. Used to detect file resets.",
             )
     except OSError as e:

--- a/stash_jellyfin_proxy/config/helpers.py
+++ b/stash_jellyfin_proxy/config/helpers.py
@@ -112,18 +112,19 @@ def save_config_value(config_file: str, key: str, value: str, comment: str = Non
             cleaned.append('\n')
         cleaned.extend(new_block)
     else:
-        # Walk back past blank lines and any decorative "# ==== ... ===="
-        # divider that visually heads the upcoming section, so a flat
-        # global key doesn't land below the divider and look like it
-        # belongs to that section.
+        # Find the most recent "# ==== ... ====" divider that precedes
+        # the first section header, and insert above it. Walking simply
+        # backwards past blank lines isn't enough — if a prior write
+        # left orphan keys between the divider and the section header
+        # (a v7.1.3-era artifact), a strict walk-back would stop at
+        # them and the new key would land below the divider. Searching
+        # the whole pre-section range catches the divider regardless.
         insertion_idx = first_section_idx
-        j = insertion_idx - 1
-        while j >= 0 and cleaned[j].strip() == '':
-            j -= 1
-        if j >= 0:
-            s = cleaned[j].strip()
+        for i in range(first_section_idx - 1, -1, -1):
+            s = cleaned[i].strip()
             if s.startswith('# ====') and s.endswith('===='):
-                insertion_idx = j
+                insertion_idx = i
+                break
         new_block.append('\n')
         cleaned[insertion_idx:insertion_idx] = new_block
 


### PR DESCRIPTION
## Summary
- **Bootstrap re-writes `CONFIG_PERSISTENCE_INTRODUCED` every boot** (preserving the prior timestamp). v7.1.3's one-shot write left the marker stuck in the wrong spot for any user who upgraded; v7.1.4's placement fix had no effect because the marker was never re-touched. Now `save_config_value` relocates it on the next boot.
- **Replaced the walk-back with a bounded backward scan** over the pre-section range. The walk-back stopped at orphan keys, so when the misplaced INTRODUCED sat between the divider and `[player.infuse]`, the new walk never found the divider and the new key joined it below. Scanning the whole range catches the divider regardless of intervening content.

## Test plan
- [x] Unit tests pass (104/104)
- [x] Simulated v7.1.3-era bad state in dev (both markers below the `# ==== Player profiles ====` divider) → first v7.1.5 boot relocates both above the divider, INTRODUCED's timestamp preserved
- [x] Second restart: no drift, exactly one comment line per marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)