### PR TITLE
v7.1.6 + v7.1.7 — Heal misplaced keys + collapse blank drift (#17)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stash-jellyfin-proxy"
-version = "7.1.5"
+version = "7.1.6"
 description = "Proxy that lets Jellyfin clients (Infuse, Findroid, etc.) browse and stream a Stash library."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stash-jellyfin-proxy"
-version = "7.1.6"
+version = "7.1.7"
 description = "Proxy that lets Jellyfin clients (Infuse, Findroid, etc.) browse and stream a Stash library."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/stash_jellyfin_proxy/__init__.py
+++ b/stash_jellyfin_proxy/__init__.py
@@ -21,4 +21,4 @@ truth; see its docstring).
 # Single source of truth for the package version. Keep in sync with
 # pyproject.toml `[project].version`. The startup banner, dashboard
 # API, and HTML brand badge all read this constant.
-__version__ = "7.1.5"
+__version__ = "7.1.6"

--- a/stash_jellyfin_proxy/__init__.py
+++ b/stash_jellyfin_proxy/__init__.py
@@ -21,4 +21,4 @@ truth; see its docstring).
 # Single source of truth for the package version. Keep in sync with
 # pyproject.toml `[project].version`. The startup banner, dashboard
 # API, and HTML brand badge all read this constant.
-__version__ = "7.1.6"
+__version__ = "7.1.7"

--- a/stash_jellyfin_proxy/config/helpers.py
+++ b/stash_jellyfin_proxy/config/helpers.py
@@ -46,6 +46,24 @@ def generate_server_id():
     return str(uuid.uuid4())
 
 
+def collapse_blank_runs(lines):
+    """Collapse runs of 2+ consecutive blank lines into a single blank
+    line. Repeated strip-and-reinsert cycles in save_config_value (e.g.
+    CONFIG_LAST_BOOT_AT, rewritten every boot) leave behind one extra
+    blank per cycle when the stripped key was bracketed by separator
+    blanks; this normalizes that drift before write.
+    """
+    out = []
+    prev_blank = False
+    for line in lines:
+        is_blank = line.strip() == ''
+        if is_blank and prev_blank:
+            continue
+        out.append(line)
+        prev_blank = is_blank
+    return out
+
+
 def find_global_insert_idx(lines):
     """Return where to insert a flat global key into `lines`, or None if
     the file has no `[section]` headers (caller should append at end).
@@ -139,6 +157,7 @@ def save_config_value(config_file: str, key: str, value: str, comment: str = Non
         new_block.append('\n')
         cleaned[insertion_idx:insertion_idx] = new_block
 
+    cleaned = collapse_blank_runs(cleaned)
     with open(config_file, 'w') as f:
         f.writelines(cleaned)
     return True

--- a/stash_jellyfin_proxy/config/helpers.py
+++ b/stash_jellyfin_proxy/config/helpers.py
@@ -46,6 +46,34 @@ def generate_server_id():
     return str(uuid.uuid4())
 
 
+def find_global_insert_idx(lines):
+    """Return where to insert a flat global key into `lines`, or None if
+    the file has no `[section]` headers (caller should append at end).
+
+    The insertion point is just before the first `[section]` header,
+    backed up over any preceding "# ==== ... ====" decorative divider
+    so the new key lands above the divider that visually heads the
+    upcoming section. Walking is over the whole pre-section range
+    (not just contiguous blanks) so misplaced keys above the section
+    header don't block the divider search.
+    """
+    first_section_idx = None
+    for i, line in enumerate(lines):
+        s = line.strip()
+        if s.startswith('[') and s.endswith(']'):
+            first_section_idx = i
+            break
+    if first_section_idx is None:
+        return None
+    insertion_idx = first_section_idx
+    for i in range(first_section_idx - 1, -1, -1):
+        s = lines[i].strip()
+        if s.startswith('# ====') and s.endswith('===='):
+            insertion_idx = i
+            break
+    return insertion_idx
+
+
 def _line_matches_key(line: str, key: str) -> bool:
     """True if `line` is `KEY = ...` or `# KEY = ...`, exact key match.
     Used so SERVER_ID doesn't collide with a hypothetical SERVER_ID_FOO."""
@@ -85,19 +113,14 @@ def save_config_value(config_file: str, key: str, value: str, comment: str = Non
     # regardless of section. Also strip any prior occurrence of the
     # same comment line we're about to insert — otherwise repeated
     # saves of a per-boot key (CONFIG_LAST_BOOT_AT) accumulate one
-    # extra comment copy per boot. Track where the first section
-    # header sits.
+    # extra comment copy per boot.
     comment_marker = f'# {comment}'.strip() if comment else None
     cleaned = []
-    first_section_idx = None
     for line in lines:
         if _line_matches_key(line, key):
             continue
         if comment_marker and line.strip() == comment_marker:
             continue
-        stripped = line.strip()
-        if first_section_idx is None and stripped.startswith('[') and stripped.endswith(']'):
-            first_section_idx = len(cleaned)
         cleaned.append(line)
 
     new_block = []
@@ -105,26 +128,14 @@ def save_config_value(config_file: str, key: str, value: str, comment: str = Non
         new_block.append(f'# {comment}\n')
     new_block.append(f'{key} = {value}\n')
 
-    if first_section_idx is None:
+    insertion_idx = find_global_insert_idx(cleaned)
+    if insertion_idx is None:
         if cleaned and not cleaned[-1].endswith('\n'):
             cleaned.append('\n')
         if cleaned and cleaned[-1].strip() != '':
             cleaned.append('\n')
         cleaned.extend(new_block)
     else:
-        # Find the most recent "# ==== ... ====" divider that precedes
-        # the first section header, and insert above it. Walking simply
-        # backwards past blank lines isn't enough — if a prior write
-        # left orphan keys between the divider and the section header
-        # (a v7.1.3-era artifact), a strict walk-back would stop at
-        # them and the new key would land below the divider. Searching
-        # the whole pre-section range catches the divider regardless.
-        insertion_idx = first_section_idx
-        for i in range(first_section_idx - 1, -1, -1):
-            s = cleaned[i].strip()
-            if s.startswith('# ====') and s.endswith('===='):
-                insertion_idx = i
-                break
         new_block.append('\n')
         cleaned[insertion_idx:insertion_idx] = new_block
 

--- a/stash_jellyfin_proxy/ui/api.py
+++ b/stash_jellyfin_proxy/ui/api.py
@@ -893,9 +893,13 @@ async def ui_api_config(request):
                 else:
                     logger.info(f"Config reverted to default: {key}: \"{old_val}\" -> default \"{default_val}\"")
 
-            # Write updated config file
+            # Write updated config file. Collapse blank-line drift
+            # introduced by prior strip-and-reinsert cycles (and by the
+            # misplaced-key pre-pass above) before writing so the file
+            # doesn't grow extra blanks every save.
+            from stash_jellyfin_proxy.config.helpers import collapse_blank_runs
             with open(runtime.CONFIG_FILE, 'w') as f:
-                f.writelines(new_lines)
+                f.writelines(collapse_blank_runs(new_lines))
 
             # Apply configuration changes immediately (where safe to do so)
             # Settings that need restart: PROXY_BIND, PROXY_PORT, UI_PORT, LOG_DIR, LOG_FILE

--- a/stash_jellyfin_proxy/ui/api.py
+++ b/stash_jellyfin_proxy/ui/api.py
@@ -650,26 +650,53 @@ async def ui_api_config(request):
             # Sensitive keys - log changes but mask values
             sensitive_keys = ["STASH_API_KEY", "SJS_PASSWORD"]
 
-            # Read existing config file preserving all lines
+            # Read existing config file preserving all lines.
+            # Pre-pass: strip any line for a known global key that
+            # appears inside a [section] block. The loader binds
+            # post-section KEY = VALUE lines to that section's dict
+            # (e.g. cfg_sections["player.default"]["FAVORITE_TAG"])
+            # instead of cfg["FAVORITE_TAG"], so a misplaced flat key
+            # is dead weight at runtime — and a previous version of
+            # this handler appended new keys at file end exactly into
+            # that trap. Strip them on read so they're effectively
+            # "absent" and get re-inserted at global scope below.
             original_lines = []
             existing_values = {}  # Currently active (uncommented) values
             all_keys_in_file = set()  # Track all keys in file (commented or not)
             if os.path.isfile(runtime.CONFIG_FILE):
                 with open(runtime.CONFIG_FILE, 'r') as f:
-                    original_lines = f.readlines()
-                    for line in original_lines:
-                        stripped = line.strip()
-                        if stripped and not stripped.startswith('#') and '=' in stripped:
-                            key, _, value = stripped.partition('=')
-                            key = key.strip()
-                            existing_values[key] = value.strip().strip('"').strip("'")
-                            all_keys_in_file.add(key)
-                        elif stripped.startswith('#') and '=' in stripped:
-                            # Track commented keys too
-                            uncommented = stripped.lstrip('#').strip()
-                            if '=' in uncommented:
-                                key, _, _ = uncommented.partition('=')
-                                all_keys_in_file.add(key.strip())
+                    raw_lines = f.readlines()
+                config_keys_set = set(config_keys)
+                current_section = None
+                for line in raw_lines:
+                    stripped = line.strip()
+                    if stripped.startswith('[') and stripped.endswith(']'):
+                        current_section = stripped[1:-1]
+                        original_lines.append(line)
+                        continue
+                    if (current_section is not None and stripped
+                            and not stripped.startswith('#') and '=' in stripped):
+                        misplaced_key, _, _ = stripped.partition('=')
+                        if misplaced_key.strip() in config_keys_set:
+                            logger.info(
+                                f"Hoisting misplaced global key out of [{current_section}]: "
+                                f"{misplaced_key.strip()}"
+                            )
+                            continue
+                    original_lines.append(line)
+                for line in original_lines:
+                    stripped = line.strip()
+                    if stripped and not stripped.startswith('#') and '=' in stripped:
+                        key, _, value = stripped.partition('=')
+                        key = key.strip()
+                        existing_values[key] = value.strip().strip('"').strip("'")
+                        all_keys_in_file.add(key)
+                    elif stripped.startswith('#') and '=' in stripped:
+                        # Track commented keys too
+                        uncommented = stripped.lstrip('#').strip()
+                        if '=' in uncommented:
+                            key, _, _ = uncommented.partition('=')
+                            all_keys_in_file.add(key.strip())
 
             # Get current running values to compare against
             current_running = {
@@ -829,10 +856,25 @@ async def ui_api_config(request):
                 else:
                     new_lines.append(line)
 
-            # Only add truly new keys that don't exist anywhere in the file
-            for key in updates:
-                if key not in updated_keys:
-                    new_lines.append(f'{key} = "{updates[key]}"\n')
+            # Only add truly new keys that don't exist anywhere in the file.
+            # Insert at global scope (before the first [section] header,
+            # backed up over the divider) so the loader treats them as
+            # flat keys — appending at end would bind them into the
+            # trailing section's dict and they'd be invisible at next
+            # bootstrap.
+            new_keys_block = [
+                f'{key} = "{updates[key]}"\n'
+                for key in updates
+                if key not in updated_keys
+            ]
+            if new_keys_block:
+                from stash_jellyfin_proxy.config.helpers import find_global_insert_idx
+                insertion_idx = find_global_insert_idx(new_lines)
+                if insertion_idx is None:
+                    new_lines.extend(new_keys_block)
+                else:
+                    new_keys_block.append('\n')
+                    new_lines[insertion_idx:insertion_idx] = new_keys_block
 
             # Log configuration changes
             for key, new_val in updates.items():


### PR DESCRIPTION
## Summary
Two commits, both addressing distinct symptoms juliuswong's diagnostic data revealed.

**v7.1.6 — Stop dashboard saves landing inside `[player.*]` sections.** Real root cause of his never-sticking favorites. The dashboard save handler appended truly-new keys at the end of the file, where the loader binds them into the trailing `[player.default]` section's dict instead of `cfg`. So `runtime.FAVORITE_TAG = ""`, the toggle endpoint short-circuits silently, no log, no Stash write, dead heart. Two parts of the fix:
- New keys are now inserted at global scope (before the first `[section]`, walking back over the `# ====` divider). Insertion-point logic is shared with `save_config_value` via a new `find_global_insert_idx()` helper.
- Pre-pass on read strips any line for a known global key that's currently sitting inside a `[section]` block, with an info-level "Hoisting misplaced global key out of [player.default]: FAVORITE_TAG" log line. The next dashboard save re-inserts at global scope, so the file heals on the next save.

**v7.1.7 — Collapse blank-line drift in config writes.** Each `save_config_value` cycle for `CONFIG_LAST_BOOT_AT` left stranded blanks where the prior key used to live and added a fresh trailing blank at the new insertion site. With two of those calls per boot, the file grew roughly one blank per restart. New `collapse_blank_runs()` helper called right before write in both file-write paths.

## Test plan
- [x] Unit tests pass (104/104)
- [x] Reproduced juliuswong's bug state in dev (`FAVORITE_TAG = "FAVORITE"` appended after `[player.default]`): runtime read empty, dashboard save healed the line to global scope with hoist log, restart confirmed `runtime.FAVORITE_TAG = "FAVORITE"`. Second restart: no further hoists (idempotent).
- [x] Production-style file with seven accumulated blanks before `CONFIG_LAST_BOOT_AT` collapsed to one blank on next save. Two consecutive restarts: 140 → 140 lines (no drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)